### PR TITLE
fix version incompatibility between ethersproject dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "identity-wallet",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1195,9 +1195,9 @@
       }
     },
     "@ethersproject/sha2": {
-      "version": "5.0.0-beta.132",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.0-beta.132.tgz",
-      "integrity": "sha512-+JVw5hOPqtgThWkmzylyLFwRonPH/YU4K9IHc7/KTMos1PERI55k1c8T8PjjuZMEo8U6QC4AgW5Ott2cUqhcmw==",
+      "version": "5.0.0-beta.133",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.0-beta.133.tgz",
+      "integrity": "sha512-XbW/6AodhLAq11RVcXp88AMdK+gHAw6Tn6QLWLMA81bs/cl2RYlIQexDdU7oKRPM/eXJBWDx+qZxFovArOutEg==",
       "requires": {
         "@ethersproject/bytes": ">=5.0.0-beta.129",
         "@ethersproject/logger": ">=5.0.0-beta.129",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "3id-blockchain-utils": "^0.3.2",
     "@babel/runtime": "^7.4.5",
     "@ethersproject/hdnode": "5.0.0-beta.133",
+    "@ethersproject/sha2": "^5.0.0-beta.133",
     "@ethersproject/wallet": "5.0.0-beta.133",
     "did-jwt": "^0.1.3",
     "events": "^3.0.0",


### PR DESCRIPTION
@ethersproject v5 beta is going through a refactor, and an export name change in beta.134 causes an error between the hdnode and sha2 packages.

This fix resolves it by adding @ethersproject/sha2-v5.0.0-beta.133 as a direct dependency to force the functioning version to be installed.

fixes #30 