### PR TITLE
release v1.1.1

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## v1.1.1 - 2020-02-12
+chore: update `hdnode` and `wallet` packages from `ethers.js`
+
 ## v1.1.0 - 2020-01-07
 feature: Add support for asymmetric encryption
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "identity-wallet",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "identity-wallet",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Create and manage identities",
   "main": "lib/identity-wallet.js",
   "directories": {


### PR DESCRIPTION
# Release Notes

## v1.1.1 - 2020-02-12
chore: update `hdnode` and `wallet` packages from `ethers.js`