### PR TITLE
fix: set DIDProvider before creating 3id doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ The function is called with one parameter which is the `request` object. It look
 ```
 In the above example the app with origin `https://my.app.origin` is requesting access to `/path/1` and `/path/2`. If the user consents to this the function should just return the `paths` array, otherwise an empty array. Note that an array containing only some of the requested paths may also be returned.
 
+#### Creating a wallet with an authentication method
+To create a wallet with an auth method you can pass two params to the create method of IDW as shown below. If the auth method doesn't have a 3ID associated with it yet IDW will create a new 3ID.
+```js
+const authSecret = new Uint8Array([ ... ]) // Entropy used to authenticate
+const authId = 'myAuthenticationMethod' // a name of the auth method
+
+const idWallet = await IdentityWallet.create({ getPermission, authSecret, authId })
+```
+
 #### Creating a wallet with a seed
 To create a wallet with a seed you can simply pass it as an option to the constructor. This will create an instance of the IdentityWallet that derives all it's keys from this seed. Be careful, if this seed is lost the identity and all of it's data will be lost as well.
 ```js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "identity-wallet",
-  "version": "2.0.0-alpha.5",
+  "version": "2.0.0-alpha.7",
   "description": "Create and manage identities",
   "main": "lib/identity-wallet.js",
   "types": "lib/identity-wallet.d.ts",

--- a/readme-template.md
+++ b/readme-template.md
@@ -44,6 +44,15 @@ The function is called with one parameter which is the `request` object. It look
 ```
 In the above example the app with origin `https://my.app.origin` is requesting access to `/path/1` and `/path/2`. If the user consents to this the function should just return the `paths` array, otherwise an empty array. Note that an array containing only some of the requested paths may also be returned.
 
+#### Creating a wallet with an authentication method
+To create a wallet with an auth method you can pass two params to the create method of IDW as shown below. If the auth method doesn't have a 3ID associated with it yet IDW will create a new 3ID.
+```js
+const authSecret = new Uint8Array([ ... ]) // Entropy used to authenticate
+const authId = 'myAuthenticationMethod' // a name of the auth method
+
+const idWallet = await IdentityWallet.create({ getPermission, authSecret, authId })
+```
+
 #### Creating a wallet with a seed
 To create a wallet with a seed you can simply pass it as an option to the constructor. This will create an instance of the IdentityWallet that derives all it's keys from this seed. Be careful, if this seed is lost the identity and all of it's data will be lost as well.
 ```js

--- a/src/identity-wallet.ts
+++ b/src/identity-wallet.ts
@@ -73,6 +73,16 @@ export default class IdentityWallet {
       keyring = new Keyring(config.seed)
       keychain = new Keychain(keyring, threeIdx)
       const pubkeys = keyring.getPublicKeys({ mgmtPub: true, useMulticodec: true })
+      // Temporarily set DID provider to create 3ID document
+      await threeIdx.setDIDProvider(
+        new DidProvider({
+          keyring,
+          permissions,
+          threeIdx,
+          forcedOrigin: SELF_ORIGIN,
+          forcedDID: `did:key:${pubkeys.managementKey as string}`,
+        })
+      )
       await threeIdx.create3idDoc(pubkeys)
     } else if (config.authSecret) {
       keychain = await Keychain.load(threeIdx, config.authSecret)

--- a/src/three-idx.ts
+++ b/src/three-idx.ts
@@ -45,6 +45,7 @@ export interface NewAuthEntry extends AuthEntry {
 }
 
 export class ThreeIDX {
+  private _managementDID: string
   public docs: Record<string, Doctype>
   public ceramic: CeramicApi
 
@@ -62,11 +63,12 @@ export class ThreeIDX {
   }
 
   get managementDID(): string {
-    return this.docs.threeId.owners[0]
+    return this._managementDID
   }
 
   async create3idDoc(publicKeys: PublicKeys): Promise<void> {
     const docParams = gen3IDgenesis(publicKeys)
+    this._managementDID = docParams.metadata.owners[0]
     this.docs.threeId = await this.ceramic.createDocument('tile', docParams)
   }
 


### PR DESCRIPTION
Since 3id document needs to be signed by the `did:key` DID we have to set the provider before this happens.