### PR TITLE
feat: Unblock key revocation signing

### DIFF
--- a/src/three-idx.ts
+++ b/src/three-idx.ts
@@ -271,6 +271,7 @@ export class ThreeIDX {
             return target.createJWS(payload, Object.assign({}, options, { did: currentController }))
           }
         } else {
+          // Idiomatic way to fall back to the original method/property.
           return Reflect.get(target, prop, receiver)
         }
       },


### PR DESCRIPTION
3id document update is signed with an appropriate did:key

Unblocks key revocation scenario.

A bit dirty, since document updates can not be individually signed by different dids yet.